### PR TITLE
[Leia] Cleanup, add settings to select colors and freq. points per line and debian build fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project(visualization.waveform)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
 
 find_package(Kodi REQUIRED)
+find_package(glm REQUIRED)
 
 if(WIN32)
   set(SHADER_FILES src/DefaultVertexShader.hlsl
@@ -31,8 +32,6 @@ if(WIN32)
   endforeach(SHADER_FILE)
   add_custom_target(generate ALL DEPENDS ${SHADER_INCLUDES})
 else()
-  find_package(glm REQUIRED)
-
   if(APP_RENDER_SYSTEM STREQUAL "gl" OR NOT APP_RENDER_SYSTEM)
     find_package(OpenGl REQUIRED)
     set(DEPLIBS ${OPENGL_LIBRARIES})
@@ -47,11 +46,12 @@ else()
 
   set(WAVEFORM_SOURCES src/Main_gl.cpp)
 
-  include_directories(${GLM_INCLUDE_DIR}
-                      ${PROJECT_SOURCE_DIR}/lib)
+  include_directories(${PROJECT_SOURCE_DIR}/lib)
 endif()
 
-include_directories(${INCLUDES} ${KODI_INCLUDE_DIR}/..)  # Hack way with "/..", need bigger Kodi cmake rework to match right include ways
+include_directories(${INCLUDES}
+                    ${GLM_INCLUDE_DIR}
+                    ${KODI_INCLUDE_DIR}/..)  # Hack way with "/..", need bigger Kodi cmake rework to match right include ways
 
 build_addon(visualization.waveform WAVEFORM DEPLIBS)
 

--- a/FindOpenGLES.cmake
+++ b/FindOpenGLES.cmake
@@ -1,9 +1,9 @@
 #.rst:
 # FindOpenGLES
 # ------------
-# Finds the OpenGLES2 library
+# Finds the OpenGLES2 and OpenGLES3 library
 #
-# This will define the following variables::
+# This will define the following variables:
 #
 # OPENGLES_FOUND - system has OpenGLES
 # OPENGLES_INCLUDE_DIRS - the OpenGLES include directory

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,8 @@ Source: kodi-visualization-waveform
 Priority: extra
 Maintainer: Nobody <nobody@kodi.tv>
 Build-Depends: debhelper (>= 9.0.0), cmake, kodi-addon-dev,
-               libgles2-mesa-dev [arm64 armhf], libgl1-mesa-dev [i386 amd64]
+               libgles2-mesa-dev [arm64 armhf], libgl1-mesa-dev [i386 amd64],
+               libglm-dev
 Standards-Version: 4.1.2
 Section: libs
 Homepage: http://kodi.tv

--- a/src/DefaultPixelShader.hlsl
+++ b/src/DefaultPixelShader.hlsl
@@ -1,5 +1,5 @@
 /*
-*      Copyright (C) 2005-2015 Team Kodi
+*      Copyright (C) 2005-2019 Team Kodi
 *      http://kodi.tv
 *
 *  This Program is free software; you can redistribute it and/or modify
@@ -13,7 +13,7 @@
 *  GNU General Public License for more details.
 *
 *  You should have received a copy of the GNU General Public License
-*  along with XBMC; see the file COPYING.  If not, see
+*  along with Kodi; see the file COPYING.  If not, see
 *  <http://www.gnu.org/licenses/>.
 *
 */

--- a/src/DefaultVertexShader.hlsl
+++ b/src/DefaultVertexShader.hlsl
@@ -1,5 +1,5 @@
 /*
-*      Copyright (C) 2005-2015 Team Kodi
+*      Copyright (C) 2005-2019 Team Kodi
 *      http://kodi.tv
 *
 *  This Program is free software; you can redistribute it and/or modify
@@ -13,7 +13,7 @@
 *  GNU General Public License for more details.
 *
 *  You should have received a copy of the GNU General Public License
-*  along with XBMC; see the file COPYING.  If not, see
+*  along with Kodi; see the file COPYING.  If not, see
 *  <http://www.gnu.org/licenses/>.
 *
 */

--- a/src/Main_dx.cpp
+++ b/src/Main_dx.cpp
@@ -1,6 +1,6 @@
 /*
- *      Copyright (C) 2008-2013 Team XBMC
- *      http://xbmc.org
+ *      Copyright (C) 2008-2019 Team Kodi
+ *      http://kodi.tv
  *
  *  This Program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -13,7 +13,7 @@
  *  GNU General Public License for more details.
  *
  *  You should have received a copy of the GNU General Public License
- *  along with XBMC; see the file COPYING.  If not, see
+ *  along with Kodi; see the file COPYING.  If not, see
  *  <http://www.gnu.org/licenses/>.
  *
  */
@@ -128,7 +128,7 @@ ADDON_STATUS CVisualizationWaveForm::Create()
 }
 
 //-- Audiodata ----------------------------------------------------------------
-// Called by XBMC to pass new audio data to the vis
+// Called by Kodi to pass new audio data to the vis
 //-----------------------------------------------------------------------------
 void CVisualizationWaveForm::AudioData(const float* pAudioData, int iAudioDataLength, float *pFreqData, int iFreqDataLength)
 {

--- a/src/Main_dx.cpp
+++ b/src/Main_dx.cpp
@@ -114,10 +114,10 @@ CVisualizationWaveForm::~CVisualizationWaveForm()
 //-----------------------------------------------------------------------------
 ADDON_STATUS CVisualizationWaveForm::Create()
 {
-  m_viewport.TopLeftX = X();
-  m_viewport.TopLeftY = Y();
-  m_viewport.Width = Width();
-  m_viewport.Height = Height();
+  m_viewport.TopLeftX = static_cast<float>(X());
+  m_viewport.TopLeftY = static_cast<float>(Y());
+  m_viewport.Width = static_cast<float>(Width());
+  m_viewport.Height = static_cast<float>(Height());
   m_viewport.MinDepth = 0;
   m_viewport.MaxDepth = 1;
   m_context = (ID3D11DeviceContext*)Device();

--- a/src/Main_dx.cpp
+++ b/src/Main_dx.cpp
@@ -28,6 +28,9 @@
 #include <DirectXPackedVector.h>
 #include <stdio.h>
 
+#include <glm/glm.hpp>
+#include <glm/gtc/type_ptr.hpp>
+
 using namespace DirectX;
 using namespace DirectX::PackedVector;
 
@@ -56,37 +59,35 @@ class CVisualizationWaveForm
     public kodi::addon::CInstanceVisualization
 {
 public:
-  CVisualizationWaveForm();
+  CVisualizationWaveForm() = default;
   ~CVisualizationWaveForm() override;
 
   ADDON_STATUS Create() override;
+  bool Start(int channels, int samplesPerSec, int bitsPerSample, std::string songName) override;
   void Render() override;
   void AudioData(const float* audioData, int audioDataLength, float *freqData, int freqDataLength) override;
 
 private:
   bool init_renderer_objs();
 
-  ID3D11Device* m_device;
-  ID3D11DeviceContext* m_context;
-  ID3D11VertexShader* m_vShader;
-  ID3D11PixelShader* m_pShader;
-  ID3D11InputLayout* m_inputLayout;
-  ID3D11Buffer* m_vBuffer;
-  ID3D11Buffer* m_cViewPort;
-  float m_fWaveform[2][512];
+  ID3D11Device* m_device = nullptr;
+  ID3D11DeviceContext* m_context = nullptr;
+  ID3D11VertexShader* m_vShader = nullptr;
+  ID3D11PixelShader* m_pShader = nullptr;
+  ID3D11InputLayout* m_inputLayout = nullptr;
+  ID3D11Buffer* m_vBuffer = nullptr;
+  ID3D11Buffer* m_cViewPort = nullptr;
+  float m_fWaveform[2][1024];
   D3D11_VIEWPORT m_viewport;
-};
+  Vertex_t m_verts[1024 * 2];
 
-CVisualizationWaveForm::CVisualizationWaveForm()
-{
-  m_device = nullptr;
-  m_context = nullptr;
-  m_vShader = nullptr;
-  m_pShader = nullptr;
-  m_inputLayout = nullptr;
-  m_vBuffer = nullptr;
-  m_cViewPort = nullptr;
-}
+  int m_usedLinePoints = 500;
+  glm::vec4 m_backgroundColor = glm::vec4(0.0f, 0.0f, 0.0f, 1.0f);
+  glm::vec4 m_lineColor = glm::vec4(0.5f, 0.5f, 0.5f, 1.0f);
+  bool m_ignoreResample = false;
+
+  bool m_startOK = false;
+};
 
 //-- Destroy ------------------------------------------------------------------
 // Do everything before unload of this add-on
@@ -127,70 +128,157 @@ ADDON_STATUS CVisualizationWaveForm::Create()
   return ADDON_STATUS_OK;
 }
 
+//-- Start -------------------------------------------------------------------
+// Called on load. Addon should fully initalize or return error status
+//-----------------------------------------------------------------------------
+bool CVisualizationWaveForm::Start(int channels, int samplesPerSec, int bitsPerSample, std::string songName)
+{
+  (void)channels;
+  (void)samplesPerSec;
+  (void)bitsPerSample;
+  (void)songName;
+
+  kodi::CheckSettingInt("points-per-line", m_usedLinePoints);
+
+  // If lines are 0 use the old style from before
+  if (m_usedLinePoints == 0)
+  {
+    m_usedLinePoints = 250;
+    m_ignoreResample = true;
+  }
+  else
+  {
+    m_ignoreResample = false;
+  }
+
+  kodi::CheckSettingFloat("line-red", m_lineColor.r);
+  kodi::CheckSettingFloat("line-green", m_lineColor.g);
+  kodi::CheckSettingFloat("line-blue", m_lineColor.b);
+
+  kodi::CheckSettingFloat("bg-red", m_backgroundColor.r);
+  kodi::CheckSettingFloat("bg-green", m_backgroundColor.g);
+  kodi::CheckSettingFloat("bg-blue", m_backgroundColor.b);
+  if (m_backgroundColor.r != 0.0f || m_backgroundColor.g != 0.0f || m_backgroundColor.b != 0.0f)
+    m_backgroundColor.a = 1.0f;
+  else
+    m_backgroundColor.a = 0.0f;
+
+  return true;
+}
+
 //-- Audiodata ----------------------------------------------------------------
 // Called by Kodi to pass new audio data to the vis
 //-----------------------------------------------------------------------------
 void CVisualizationWaveForm::AudioData(const float* pAudioData, int iAudioDataLength, float *pFreqData, int iFreqDataLength)
 {
-  int ipos=0;
-  while (ipos < 512)
+  (void)pFreqData;
+  (void)iFreqDataLength;
+
+  int ipos = 0;
+  int length = iAudioDataLength;
+  int usedStep;
+  if (m_ignoreResample)
   {
-    for (int i=0; i < iAudioDataLength; i+=2)
+    usedStep = 2;
+  }
+  else
+  {
+    usedStep = (iAudioDataLength / m_usedLinePoints) & ~1;
+    usedStep = usedStep < 2 ? 2 : usedStep;
+  }
+
+  while (ipos < m_usedLinePoints)
+  {
+    for (int i=0; i < length; i+=usedStep)
     {
       m_fWaveform[0][ipos] = pAudioData[i  ]; // left channel
       m_fWaveform[1][ipos] = pAudioData[i+1]; // right channel
       ipos++;
-      if (ipos >= 512) break;
+      if (ipos >= m_usedLinePoints)
+         break;
     }
   }
 }
-
 
 //-- Render -------------------------------------------------------------------
 // Called once per frame. Do all rendering here.
 //-----------------------------------------------------------------------------
 void CVisualizationWaveForm::Render()
 {
-  Vertex_t  verts[512];
-
+  D3D11_MAPPED_SUBRESOURCE res;
   unsigned stride = sizeof(Vertex_t), offset = 0;
   m_context->IASetVertexBuffers(0, 1, &m_vBuffer, &stride, &offset);
   m_context->IASetInputLayout(m_inputLayout);
-  m_context->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_LINESTRIP);
   m_context->VSSetShader(m_vShader, 0, 0);
   m_context->VSSetConstantBuffers(0, 1, &m_cViewPort);
   m_context->PSSetShader(m_pShader, 0, 0);
-  float xcolor[4] = { 1.0f, 1.0f, 1.0f, 1.0f };
 
-  // Left channel
-  for (int i = 0; i < 256; i++)
+  if (m_backgroundColor.a != 0.0f)
   {
-    verts[i].col = XMFLOAT4(xcolor);;
-    verts[i].x = m_viewport.TopLeftX + ((i / 255.0f) * m_viewport.Width);
-    verts[i].y = m_viewport.TopLeftY + m_viewport.Height * 0.33f + (m_fWaveform[0][i] * m_viewport.Height * 0.15f);
-    verts[i].z = 1.0;
+    m_context->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
+
+    // Set background color
+    for (int i = 0; i < 5; i++)
+      m_verts[i].col = XMFLOAT4(glm::value_ptr(m_backgroundColor));
+    m_verts[0].x = m_viewport.TopLeftX;
+    m_verts[0].y = m_viewport.TopLeftY;
+    m_verts[0].z = 1.0;
+    m_verts[1].x = m_viewport.TopLeftX;
+    m_verts[1].y = m_viewport.TopLeftY + m_viewport.Height;
+    m_verts[1].z = 1.0;
+    m_verts[2].x = m_viewport.TopLeftX + m_viewport.Width;
+    m_verts[2].y = m_viewport.TopLeftY + m_viewport.Height;
+    m_verts[2].z = 1.0;
+    m_verts[3].x = m_viewport.TopLeftX + m_viewport.Width;
+    m_verts[3].y = m_viewport.TopLeftY;
+    m_verts[3].z = 1.0;
+    m_verts[4].x = m_viewport.TopLeftX;
+    m_verts[4].y = m_viewport.TopLeftY;
+    m_verts[4].z = 1.0;
+
+    // a little optimization: generate and send all vertecies for both channels
+    if (S_OK == m_context->Map(m_vBuffer, 0, D3D11_MAP_WRITE_DISCARD, 0, &res))
+    {
+      memcpy(res.pData, m_verts, sizeof(Vertex_t) * 5);
+      m_context->Unmap(m_vBuffer, 0);
+    }
+    // draw background
+    m_context->Draw(5, 0);
+  }
+
+  m_context->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_LINESTRIP);
+
+  int j = 0;
+  // Left channel
+  for (int i = 0; i < m_usedLinePoints; i++)
+  {
+    m_verts[j].col = XMFLOAT4(glm::value_ptr(m_lineColor));
+    m_verts[j].x = m_viewport.TopLeftX + (-1.0f + ((i / float(m_usedLinePoints)) * 2.0f) * m_viewport.Width);
+    m_verts[j].y = m_viewport.TopLeftY + m_viewport.Height * 0.25f + (m_fWaveform[0][i] * m_viewport.Height * 0.3f);
+    m_verts[j].z = 1.0;
+    j++;
   }
 
   // Right channel
-  for (int i = 256; i < 512; i++)
+  for (int i = 0; i < m_usedLinePoints; i++)
   {
-    verts[i].col = XMFLOAT4(xcolor);
-    verts[i].x = m_viewport.TopLeftX + (((i - 256) / 255.0f) * m_viewport.Width);
-    verts[i].y = m_viewport.TopLeftY + m_viewport.Height * 0.66f + (m_fWaveform[1][i] * m_viewport.Height * 0.15f);
-    verts[i].z = 1.0;
+    m_verts[j].col = XMFLOAT4(glm::value_ptr(m_lineColor));
+    m_verts[j].x = m_viewport.TopLeftX + (-1.0f + ((i / float(m_usedLinePoints)) * 2.0f) * m_viewport.Width);
+    m_verts[j].y = m_viewport.TopLeftY + m_viewport.Height * 0.75f + (m_fWaveform[1][i] * m_viewport.Height * 0.3f);
+    m_verts[j].z = 1.0;
+    j++;
   }
 
   // a little optimization: generate and send all vertecies for both channels
-  D3D11_MAPPED_SUBRESOURCE res;
   if (S_OK == m_context->Map(m_vBuffer, 0, D3D11_MAP_WRITE_DISCARD, 0, &res))
   {
-    memcpy(res.pData, verts, sizeof(Vertex_t) * 512);
+    memcpy(res.pData, m_verts, sizeof(Vertex_t) * j);
     m_context->Unmap(m_vBuffer, 0);
   }
   // draw left channel
-  m_context->Draw(256, 0);
+  m_context->Draw(m_usedLinePoints, 0);
   // draw right channel
-  m_context->Draw(256, 256);
+  m_context->Draw(m_usedLinePoints, m_usedLinePoints);
 }
 
 bool CVisualizationWaveForm::init_renderer_objs()
@@ -213,7 +301,7 @@ bool CVisualizationWaveForm::init_renderer_objs()
     return false;
 
   // create buffers
-  CD3D11_BUFFER_DESC desc(sizeof(Vertex_t) * 512, D3D11_BIND_VERTEX_BUFFER, D3D11_USAGE_DYNAMIC, D3D11_CPU_ACCESS_WRITE);
+  CD3D11_BUFFER_DESC desc(sizeof(Vertex_t) * 1024 * 2, D3D11_BIND_VERTEX_BUFFER, D3D11_USAGE_DYNAMIC, D3D11_CPU_ACCESS_WRITE);
   if (S_OK != m_device->CreateBuffer(&desc, NULL, &m_vBuffer))
     return false;
 

--- a/src/Main_gl.cpp
+++ b/src/Main_gl.cpp
@@ -1,5 +1,8 @@
-/*  XMMS - Cross-platform multimedia player
- *  Copyright (C) 1998-2000  Peter Alm, Mikael Alm, Olle Hallnas, Thomas Nilsson and 4Front Technologies
+/*
+ *      XMMS - Cross-platform multimedia player
+ *      Copyright (C) 1998-2000  Peter Alm, Mikael Alm, Olle Hallnas, Thomas Nilsson and 4Front Technologies
+ *      Copyright (C) 2008-2019 Team Kodi
+ *      http://kodi.tv
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/visualization.waveform/addon.xml.in
+++ b/visualization.waveform/addon.xml.in
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="visualization.waveform"
-  version="3.0.2"
+  version="3.1.0"
   name="Waveform"
   provider-name="MrC">
   <requires>@ADDON_DEPENDS@</requires>

--- a/visualization.waveform/addon.xml.in
+++ b/visualization.waveform/addon.xml.in
@@ -117,6 +117,8 @@
     <description lang="zh">Waveform 是一个简单的可视化效果，它在屏幕上显示两个波形图，分别与音乐左右声道的节拍相呼应。</description>
     <description lang="zh_TW">Waveform是一個簡單的可在屏幕上顯示2波形圖的視覺效果，左右聲道會跟著音樂節拍移動</description>
     <platform>@PLATFORM@</platform>
+    <license>GPL-3.0</license>
+    <source>https://github.com/xbmc/visualization.waveform</source>
     <assets>
       <icon>resources/icon.png</icon>
       <fanart>resources/fanart.png</fanart>

--- a/visualization.waveform/resources/language/resource.language.en_gb/strings.po
+++ b/visualization.waveform/resources/language/resource.language.en_gb/strings.po
@@ -1,0 +1,103 @@
+# Kodi Media Center language file
+# Addon Name: OpenGL Waveform
+# Addon id: visualization.waveform
+# Addon Provider: Team Kodi
+msgid ""
+msgstr ""
+"Project-Id-Version: KODI Addons\n"
+"Report-Msgid-Bugs-To: https://github.com/xbmc/visualization.waveform/issues\n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: Kodi Translation Team\n"
+"Language-Team: English (https://www.transifex.com/teamxbmc/kodi-addons/language/en_GB/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: en\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#settings labels
+
+msgctxt "#30000"
+msgid "Points per line"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Positions to represent the current frequency in a line."
+msgstr ""
+
+msgctxt "#30002"
+msgid "Line color"
+msgstr ""
+
+msgctxt "#30003"
+msgid "Red"
+msgstr ""
+
+msgctxt "#30004"
+msgid "Strength of red color in the line"
+msgstr ""
+
+msgctxt "#30005"
+msgid "Green"
+msgstr ""
+
+msgctxt "#30006"
+msgid "Strength of green color in the line"
+msgstr ""
+
+msgctxt "#30007"
+msgid "Blue"
+msgstr ""
+
+msgctxt "#30008"
+msgid "Strength of blue color in the line"
+msgstr ""
+
+msgctxt "#30009"
+msgid "Alpha"
+msgstr ""
+
+msgctxt "#30010"
+msgid "Strength of alpha in the line"
+msgstr ""
+
+msgctxt "#30011"
+msgid "Background color"
+msgstr ""
+
+msgctxt "#30012"
+msgid "Red"
+msgstr ""
+
+msgctxt "#30013"
+msgid "Strength of red color in the background"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Green"
+msgstr ""
+
+msgctxt "#30015"
+msgid "Strength of green color in the background"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Blue"
+msgstr ""
+
+msgctxt "#30017"
+msgid "Strength of blue color in the background"
+msgstr ""
+
+msgctxt "#30018"
+msgid "Alpha"
+msgstr ""
+
+msgctxt "#30019"
+msgid "Strength of alpha in the background"
+msgstr ""
+
+msgctxt "#30020"
+msgid "Don't calculate"
+msgstr ""

--- a/visualization.waveform/resources/settings.xml
+++ b/visualization.waveform/resources/settings.xml
@@ -1,0 +1,75 @@
+<settings version="1">
+  <section id="addon" label="0" help="0">
+    <category id="main" label="128" help="0">
+      <group id="1" label="0">
+        <setting id="points-per-line" type="integer" label="30000" help="30001">
+          <default>500</default>
+          <constraints>
+            <minimum label="30020">0</minimum>
+            <step>250</step>
+            <maximum>1000</maximum>
+          </constraints>
+          <control type="spinner" format="string" />
+        </setting>
+      </group>
+      <group id="2" label="30002">
+        <setting id="line-red" type="number" label="30003" help="30004">
+          <default>0.5</default>
+          <constraints>
+            <minimum>0.0</minimum>
+            <step>0.1</step>
+            <maximum>1.0</maximum>
+          </constraints>
+          <control type="slider" format="number" />
+        </setting>
+        <setting id="line-green" type="number" label="30005" help="30006">
+          <default>0.5</default>
+          <constraints>
+            <minimum>0.0</minimum>
+            <step>0.1</step>
+            <maximum>1.0</maximum>
+          </constraints>
+          <control type="slider" format="number" />
+        </setting>
+        <setting id="line-blue" type="number" label="30007" help="30008">
+          <default>0.5</default>
+          <constraints>
+            <minimum>0.0</minimum>
+            <step>0.1</step>
+            <maximum>1.0</maximum>
+          </constraints>
+          <control type="slider" format="number" />
+        </setting>
+      </group>
+      <group id="3" label="30011">
+        <setting id="bg-red" type="number" label="30012" help="30013">
+          <default>0.0</default>
+          <constraints>
+            <minimum>0.0</minimum>
+            <step>0.1</step>
+            <maximum>1.0</maximum>
+          </constraints>
+          <control type="slider" format="number" />
+        </setting>
+        <setting id="bg-green" type="number" label="30014" help="30015">
+          <default>0.0</default>
+          <constraints>
+            <minimum>0.0</minimum>
+            <step>0.1</step>
+            <maximum>1.0</maximum>
+          </constraints>
+          <control type="slider" format="number" />
+        </setting>
+        <setting id="bg-blue" type="number" label="30016" help="30017">
+          <default>0.0</default>
+          <constraints>
+            <minimum>0.0</minimum>
+            <step>0.1</step>
+            <maximum>1.0</maximum>
+          </constraints>
+          <control type="slider" format="number" />
+        </setting>
+      </group>
+    </category>
+  </section>
+</settings>

--- a/visualization.waveform/resources/shaders/GL/vert.glsl
+++ b/visualization.waveform/resources/shaders/GL/vert.glsl
@@ -7,7 +7,7 @@ in vec4 a_color;
 
 out vec4 v_color;
 
-void main ()
+void main()
 {
   gl_Position = u_modelViewProjectionMatrix * a_position;
   v_color = a_color;


### PR DESCRIPTION
This is a major change (only with version on Matrix present is it only 0.0.1 more here).

It make DX and GL view on Kodi mosty equal. Further is the processing improved where reduce the CPU consumption.

Also are settings added with the new feature to select background color and line color.
Further seen that most parts from audiostream was not used and the view was never continues. In new settings can be this selected to have as old style or with a amount of frequency points in line.

Seen further during DX test that bug was before where the second line was not shown correct. Fixed with them.

![Screenshot_20191008_051633](https://user-images.githubusercontent.com/6879739/66364716-f9f74000-e98a-11e9-8500-b284b7c45586.png)

![Screenshot_20191008_051710](https://user-images.githubusercontent.com/6879739/66364726-0085b780-e98b-11e9-952c-76c04374a9e4.png)

![Screenshot_20191008_053208](https://user-images.githubusercontent.com/6879739/66365411-1f854900-e98d-11e9-88b3-ba8d6f0116db.png)